### PR TITLE
Fix NaN division warnings

### DIFF
--- a/common/Chl_CONNECT.py
+++ b/common/Chl_CONNECT.py
@@ -147,7 +147,13 @@ class Chl_CONNECT:
         mask2=Chl[:,1]>15000
         p2[mask2]=0
         
-        self.Chl_comb = (p1*Chl[:,0] + p2*Chl[:,1])/(p1+p2)
+        denom = p1 + p2
+        # Avoid division by zero when both probabilities are zero
+        with np.errstate(divide='ignore', invalid='ignore'):
+            self.Chl_comb = np.divide(p1*Chl[:,0] + p2*Chl[:,1],
+                                      denom,
+                                      out=np.full_like(denom, np.nan, dtype=float),
+                                      where=denom != 0)
         
         # Reshape results to match input dimensions
         self.Chl_comb = self.Chl_comb.reshape(init_shape)

--- a/common/classification_functions.py
+++ b/common/classification_functions.py
@@ -24,9 +24,12 @@ def normalize_Rrs(Rrs,wave_lengths):
         normalized_data = normalize_Rrs(Rrs_data, wave_lengths)
     """
     area = trapezoid(Rrs, wave_lengths, axis=1)
-    
+
+    # Avoid division by zero by replacing zero areas with NaN
+    area_safe = np.where(area == 0, np.nan, area)
+
     # Normalize Rrs by the calculated area
-    Rrs_norm = Rrs / area[:, np.newaxis]
+    Rrs_norm = Rrs / area_safe[:, np.newaxis]
     return Rrs_norm
 
 def probability(model, rrs_norm, 


### PR DESCRIPTION
## Summary
- avoid dividing by zero in `normalize_Rrs`
- avoid zero denominator when combining chlorophyll results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68835e89bb38833395a6628d7daf2c60